### PR TITLE
chore: promote jx3-demo-golang-http-2021-01-16 to version 0.0.2

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/jx3-demo-golang-http-2021-01-16
-  version: 0.0.1
+  version: 0.0.2
   name: jx3-demo-golang-http-2021-01-16
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote jx3-demo-golang-http-2021-01-16 to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge