### PR TITLE
chore: promote jx3-demo-golang-http-2021-01-16 to version 0.0.4

### DIFF
--- a/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-0.0.4-release.yaml
+++ b/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-0.0.4-release.yaml
@@ -1,0 +1,39 @@
+# Source: jx3-demo-golang-http-2021-01-16/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-18T15:04:00Z"
+  deletionTimestamp: null
+  name: 'jx3-demo-golang-http-2021-01-16-0.0.4'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.4
+      sha: 6f9aedb0b6d2646577e89a5c8a172e7da3638f8a
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 36aed5e8bb82926dca49c3f6a3b1ffdfacfa67c4
+  gitHttpUrl: https://github.com/ascheman/jx3-demo-golang-http-2021-01-16
+  gitOwner: ascheman
+  gitRepository: jx3-demo-golang-http-2021-01-16
+  name: 'jx3-demo-golang-http-2021-01-16'
+  releaseNotesURL: https://github.com/ascheman/jx3-demo-golang-http-2021-01-16/releases/tag/v0.0.4
+  version: v0.0.4
+status: {}

--- a/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-ingress.yaml
+++ b/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: jx3-demo-golang-http-2021-01-16/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: public
+  name: jx3-demo-golang-http-2021-01-16
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: jx3-demo-golang-http-2021-01-16
+              servicePort: 80
+      host: jx3-demo-golang-http-2021-01-16-jx-production.k8s0.dukecon.org

--- a/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-jx3-demo-golang-http-2021-01-16-deploy.yaml
+++ b/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-jx3-demo-golang-http-2021-01-16-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: jx3-demo-golang-http-2021-01-16/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx3-demo-golang-http-2021-01-16-jx3-demo-golang-http-2021-01-16
+  labels:
+    draft: draft-app
+    chart: "jx3-demo-golang-http-2021-01-16-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: jx3-demo-golang-http-2021-01-16-jx3-demo-golang-http-2021-01-16
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx3-demo-golang-http-2021-01-16-jx3-demo-golang-http-2021-01-16
+    spec:
+      serviceAccountName: jx3-demo-golang-http-2021-01-16-jx3-demo-golang-http-2021-01-16
+      containers:
+        - name: jx3-demo-golang-http-2021-01-16
+          image: "10.152.183.96/ascheman/jx3-demo-golang-http-2021-01-16:0.0.4"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.4
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-jx3-demo-golang-http-2021-01-16-sa.yaml
+++ b/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-jx3-demo-golang-http-2021-01-16-sa.yaml
@@ -1,0 +1,8 @@
+# Source: jx3-demo-golang-http-2021-01-16/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jx3-demo-golang-http-2021-01-16-jx3-demo-golang-http-2021-01-16
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-svc.yaml
+++ b/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-svc.yaml
@@ -1,0 +1,21 @@
+# Source: jx3-demo-golang-http-2021-01-16/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jx3-demo-golang-http-2021-01-16
+  labels:
+    chart: "jx3-demo-golang-http-2021-01-16-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx3-demo-golang-http-2021-01-16-jx3-demo-golang-http-2021-01-16

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -7,5 +7,11 @@ namespace: jx-production
 repositories:
 - name: dev
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
+- name: dev2
+  url: https://github.com/ascheman/helmcharts.git
+releases:
+- chart: dev2/jx3-demo-golang-http-2021-01-16
+  version: 0.0.4
+  name: jx3-demo-golang-http-2021-01-16
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -6,11 +6,9 @@ environments:
 namespace: jx-production
 repositories:
 - name: dev
-  url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
-- name: dev2
-  url: https://github.com/ascheman/helmcharts.git
+  url: https://ascheman.github.io/helmcharts/
 releases:
-- chart: dev2/jx3-demo-golang-http-2021-01-16
+- chart: dev/jx3-demo-golang-http-2021-01-16
   version: 0.0.4
   name: jx3-demo-golang-http-2021-01-16
 templates: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev/jx3-demo-golang-http-2021-01-16
   version: 0.0.4
   name: jx3-demo-golang-http-2021-01-16
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote jx3-demo-golang-http-2021-01-16 to version 0.0.4

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge