### PR TITLE
chore: promote jx3-demo-spring-boot-2021-01-18 to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-demo-spring-boot-2021-01-18/jx3-demo-spring-boot-2021-01-18-0.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demo-spring-boot-2021-01-18/jx3-demo-spring-boot-2021-01-18-0.0.2-release.yaml
@@ -1,0 +1,59 @@
+# Source: jx3-demo-spring-boot-2021-01-18/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-18T16:19:53Z"
+  deletionTimestamp: null
+  name: 'jx3-demo-spring-boot-2021-01-18-0.0.2'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.2
+      sha: aab45b889e798ec76948e2b9be7128f222a70b15
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 3b282c9f1a8965d6cb5d1c4f146160613cb23237
+    - author:
+        email: gerd@aschemann.net
+        name: Gerd Aschemann
+      branch: master
+      committer:
+        email: gerd@aschemann.net
+        name: Gerd Aschemann
+      message: |
+        fix(plugins): use a better version of maven plugins
+      sha: 9a0392c86f2eff51067556bb53d68ca5fbda6ba2
+    - author:
+        email: gerd@aschemann.net
+        name: Gerd Aschemann
+      branch: master
+      committer:
+        email: gerd@aschemann.net
+        name: Gerd Aschemann
+      message: |
+        chore: Jenkins X build pack
+      sha: b4e5b48b535f205d4641f4f55edf9af85b1af653
+  gitHttpUrl: https://github.com/ascheman/jx3-demo-spring-boot-2021-01-18
+  gitOwner: ascheman
+  gitRepository: jx3-demo-spring-boot-2021-01-18
+  name: 'jx3-demo-spring-boot-2021-01-18'
+  releaseNotesURL: https://github.com/ascheman/jx3-demo-spring-boot-2021-01-18/releases/tag/v0.0.2
+  version: v0.0.2
+status: {}

--- a/config-root/namespaces/jx-staging/jx3-demo-spring-boot-2021-01-18/jx3-demo-spring-boot-2021-01-18-ingress.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demo-spring-boot-2021-01-18/jx3-demo-spring-boot-2021-01-18-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: jx3-demo-spring-boot-2021-01-18/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: jx3-demo-spring-boot-2021-01-18
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: jx3-demo-spring-boot-2021-01-18
+              servicePort: 80
+      host: jx3-demo-spring-boot-2021-01-18-jx-staging.k8s0.dukecon.org

--- a/config-root/namespaces/jx-staging/jx3-demo-spring-boot-2021-01-18/jx3-demo-spring-boot-2021-01-18-jx3-demo-spring-boot-2021-01-18-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demo-spring-boot-2021-01-18/jx3-demo-spring-boot-2021-01-18-jx3-demo-spring-boot-2021-01-18-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: jx3-demo-spring-boot-2021-01-18/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx3-demo-spring-boot-2021-01-18-jx3-demo-spring-boot-2021-01-18
+  labels:
+    draft: draft-app
+    chart: "jx3-demo-spring-boot-2021-01-18-0.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: jx3-demo-spring-boot-2021-01-18-jx3-demo-spring-boot-2021-01-18
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx3-demo-spring-boot-2021-01-18-jx3-demo-spring-boot-2021-01-18
+    spec:
+      serviceAccountName: jx3-demo-spring-boot-2021-01-18-jx3-demo-spring-boot-2021-01-18
+      containers:
+        - name: jx3-demo-spring-boot-2021-01-18
+          image: "10.152.183.96/ascheman/jx3-demo-spring-boot-2021-01-18:0.0.2"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.2
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/jx3-demo-spring-boot-2021-01-18/jx3-demo-spring-boot-2021-01-18-jx3-demo-spring-boot-2021-01-18-sa.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demo-spring-boot-2021-01-18/jx3-demo-spring-boot-2021-01-18-jx3-demo-spring-boot-2021-01-18-sa.yaml
@@ -1,0 +1,8 @@
+# Source: jx3-demo-spring-boot-2021-01-18/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jx3-demo-spring-boot-2021-01-18-jx3-demo-spring-boot-2021-01-18
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/jx3-demo-spring-boot-2021-01-18/jx3-demo-spring-boot-2021-01-18-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demo-spring-boot-2021-01-18/jx3-demo-spring-boot-2021-01-18-svc.yaml
@@ -1,0 +1,21 @@
+# Source: jx3-demo-spring-boot-2021-01-18/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jx3-demo-spring-boot-2021-01-18
+  labels:
+    chart: "jx3-demo-spring-boot-2021-01-18-0.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx3-demo-spring-boot-2021-01-18-jx3-demo-spring-boot-2021-01-18

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,15 +7,13 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: https://ascheman.github.io/helmcharts/
-- name: dev2
-  url: https://github.com/ascheman/helmcharts.git
 releases:
 - chart: dev/jx3-demo-golang-http-2021-01-16
   version: 0.0.4
   name: jx3-demo-golang-http-2021-01-16
   values:
   - jx-values.yaml
-- chart: dev2/jx3-demo-spring-boot-2021-01-18
+- chart: dev/jx3-demo-spring-boot-2021-01-18
   version: 0.0.2
   name: jx3-demo-spring-boot-2021-01-18
 templates: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,11 +7,16 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: https://ascheman.github.io/helmcharts/
+- name: dev2
+  url: https://github.com/ascheman/helmcharts.git
 releases:
 - chart: dev/jx3-demo-golang-http-2021-01-16
   version: 0.0.4
   name: jx3-demo-golang-http-2021-01-16
   values:
   - jx-values.yaml
+- chart: dev2/jx3-demo-spring-boot-2021-01-18
+  version: 0.0.2
+  name: jx3-demo-spring-boot-2021-01-18
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/jx3-demo-spring-boot-2021-01-18
   version: 0.0.2
   name: jx3-demo-spring-boot-2021-01-18
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote jx3-demo-spring-boot-2021-01-18 to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge