### PR TITLE
chore: promote jx3-demo-spring-boot-2021-01-18 to version 0.0.2

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -7,11 +7,16 @@ namespace: jx-production
 repositories:
 - name: dev
   url: https://ascheman.github.io/helmcharts/
+- name: dev2
+  url: https://github.com/ascheman/helmcharts.git
 releases:
 - chart: dev/jx3-demo-golang-http-2021-01-16
   version: 0.0.4
   name: jx3-demo-golang-http-2021-01-16
   values:
   - jx-values.yaml
+- chart: dev2/jx3-demo-spring-boot-2021-01-18
+  version: 0.0.2
+  name: jx3-demo-spring-boot-2021-01-18
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote jx3-demo-spring-boot-2021-01-18 to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge