### PR TITLE
chore: promote jx3-demo-golang-http-2021-01-16 to version 0.0.5

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,9 +7,11 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: https://ascheman.github.io/helmcharts/
+- name: dev2
+  url: https://github.com/ascheman/helmcharts.git
 releases:
 - chart: dev/jx3-demo-golang-http-2021-01-16
-  version: 0.0.4
+  version: 0.0.5
   name: jx3-demo-golang-http-2021-01-16
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote jx3-demo-golang-http-2021-01-16 to version 0.0.5

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge