### PR TITLE
chore: promote jx3-demo-golang-http-2021-01-16 to version 0.0.6

### DIFF
--- a/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-0.0.6-release.yaml
+++ b/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-0.0.6-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-18T15:04:00Z"
+  creationTimestamp: "2021-01-18T23:12:49Z"
   deletionTimestamp: null
-  name: 'jx3-demo-golang-http-2021-01-16-0.0.4'
+  name: 'jx3-demo-golang-http-2021-01-16-0.0.6'
   namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.4
-      sha: 6f9aedb0b6d2646577e89a5c8a172e7da3638f8a
+        chore: release 0.0.6
+      sha: 9b57fd8be906d0c6a1dff0949b51e754db70164a
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,11 +29,21 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 36aed5e8bb82926dca49c3f6a3b1ffdfacfa67c4
+      sha: 015af356806e3420ebb8f2af952455ec00e56107
+    - author:
+        email: gerd@aschemann.net
+        name: Gerd Aschemann
+      branch: master
+      committer:
+        email: gerd@aschemann.net
+        name: Gerd Aschemann
+      message: |
+        Use jx-promote which publishes chart to GH pages
+      sha: 059383b25f0df64207f8c093952fd91d9f1294e4
   gitHttpUrl: https://github.com/ascheman/jx3-demo-golang-http-2021-01-16
   gitOwner: ascheman
   gitRepository: jx3-demo-golang-http-2021-01-16
   name: 'jx3-demo-golang-http-2021-01-16'
-  releaseNotesURL: https://github.com/ascheman/jx3-demo-golang-http-2021-01-16/releases/tag/v0.0.4
-  version: v0.0.4
+  releaseNotesURL: https://github.com/ascheman/jx3-demo-golang-http-2021-01-16/releases/tag/v0.0.6
+  version: v0.0.6
 status: {}

--- a/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-jx3-demo-golang-http-2021-01-16-deploy.yaml
+++ b/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-jx3-demo-golang-http-2021-01-16-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-demo-golang-http-2021-01-16-jx3-demo-golang-http-2021-01-16
   labels:
     draft: draft-app
-    chart: "jx3-demo-golang-http-2021-01-16-0.0.4"
+    chart: "jx3-demo-golang-http-2021-01-16-0.0.6"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: jx3-demo-golang-http-2021-01-16-jx3-demo-golang-http-2021-01-16
       containers:
         - name: jx3-demo-golang-http-2021-01-16
-          image: "10.152.183.96/ascheman/jx3-demo-golang-http-2021-01-16:0.0.4"
+          image: "10.152.183.96/ascheman/jx3-demo-golang-http-2021-01-16:0.0.6"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.4
+              value: 0.0.6
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-svc.yaml
+++ b/config-root/namespaces/jx-production/jx3-demo-golang-http-2021-01-16/jx3-demo-golang-http-2021-01-16-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-demo-golang-http-2021-01-16
   labels:
-    chart: "jx3-demo-golang-http-2021-01-16-0.0.4"
+    chart: "jx3-demo-golang-http-2021-01-16-0.0.6"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://ascheman.github.io/helmcharts/
 releases:
 - chart: dev/jx3-demo-golang-http-2021-01-16
-  version: 0.0.4
+  version: 0.0.6
   name: jx3-demo-golang-http-2021-01-16
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote jx3-demo-golang-http-2021-01-16 to version 0.0.6

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
